### PR TITLE
ADQ-34 Repackage health API and parent sentinel classes

### DIFF
--- a/sentinel/src/main/java/gov/va/api/health/sentinel/Environment.java
+++ b/sentinel/src/main/java/gov/va/api/health/sentinel/Environment.java
@@ -38,8 +38,4 @@ public enum Environment {
   private static String sentinelProperty() {
     return System.getProperty("sentinel", "LOCAL").toUpperCase(Locale.ENGLISH);
   }
-
-  public boolean foo() {
-    return true;
-  }
 }

--- a/sentinel/src/main/java/gov/va/api/health/sentinel/Environment.java
+++ b/sentinel/src/main/java/gov/va/api/health/sentinel/Environment.java
@@ -18,7 +18,7 @@ public enum Environment {
   }
 
   /** Parse the system property 'sentinel' into the appropriate enum. */
-  static Environment get() {
+  public static Environment get() {
     switch (sentinelProperty()) {
       case "LAB":
         return Environment.LAB;
@@ -37,5 +37,9 @@ public enum Environment {
 
   private static String sentinelProperty() {
     return System.getProperty("sentinel", "LOCAL").toUpperCase(Locale.ENGLISH);
+  }
+
+  public boolean foo() {
+    return true;
   }
 }

--- a/sentinel/src/main/java/gov/va/api/health/sentinel/ErrorsAreFunctionallyEqual.java
+++ b/sentinel/src/main/java/gov/va/api/health/sentinel/ErrorsAreFunctionallyEqual.java
@@ -2,6 +2,7 @@ package gov.va.api.health.sentinel;
 
 import io.restassured.response.ResponseBody;
 
-public interface ResponsesAreFunctionallyEqualCheck {
+@FunctionalInterface
+public interface ErrorsAreFunctionallyEqual {
   boolean equals(ResponseBody<?> responseBody1, ResponseBody<?> responseBody2);
 }

--- a/sentinel/src/main/java/gov/va/api/health/sentinel/ExpectedResponse.java
+++ b/sentinel/src/main/java/gov/va/api/health/sentinel/ExpectedResponse.java
@@ -17,11 +17,11 @@ import lombok.Value;
  */
 @Value
 @AllArgsConstructor(staticName = "of")
-class ExpectedResponse {
+public class ExpectedResponse {
   Response response;
 
   /** Expect the HTTP status code to be the given value. */
-  ExpectedResponse expect(int statusCode) {
+  public ExpectedResponse expect(int statusCode) {
     try {
       response.then().statusCode(statusCode);
     } catch (AssertionError e) {
@@ -48,7 +48,7 @@ class ExpectedResponse {
    * Expect the body to be a JSON list represented by the given type, using the project standard
    * {@link JacksonConfig} object mapper.
    */
-  <T> List<T> expectListOf(Class<T> type) {
+  public <T> List<T> expectListOf(Class<T> type) {
     try {
       ObjectMapper mapper = JacksonConfig.createMapper();
       return mapper.readValue(
@@ -64,7 +64,7 @@ class ExpectedResponse {
    * Expect the body to be JSON represented by the given type, using the project standard {@link
    * JacksonConfig} object mapper, then perform Javax Validation against it.
    */
-  <T> T expectValid(Class<T> type) {
+  public <T> T expectValid(Class<T> type) {
     T payload = expect(type);
     Set<ConstraintViolation<T>> violations =
         Validation.buildDefaultValidatorFactory().getValidator().validate(payload);

--- a/sentinel/src/main/java/gov/va/api/health/sentinel/FhirTestClient.java
+++ b/sentinel/src/main/java/gov/va/api/health/sentinel/FhirTestClient.java
@@ -1,0 +1,139 @@
+package gov.va.api.health.sentinel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.http.Method;
+import io.restassured.response.Response;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import lombok.Builder;
+import lombok.SneakyThrows;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The FhirTestClient bakes in some functionality such as making the requests with all three
+ * supported content types: application/json, application/fhir+json, and application/json+fhir. When
+ * using this test client, callers will need to furnish a ResponsesAreFunctionallyEqualCheck that
+ * will determine whether each of the three content types returns a functionally equivalent
+ * (ignoring transient data like timestamps and sequence numbers) response.
+ */
+@Slf4j
+@Value
+@Builder
+public final class FhirTestClient implements TestClient {
+  private final ServiceDefinition service;
+
+  private final ExecutorService executorService =
+      Executors.newFixedThreadPool(
+          SentinelProperties.threadCount(
+              "sentinel.threads", Runtime.getRuntime().availableProcessors()));
+
+  private final ResponsesAreFunctionallyEqualCheck functionalEqualityCheck;
+
+  Supplier<ObjectMapper> mapper;
+
+  @Override
+  @SneakyThrows
+  public ExpectedResponse get(String path, String... params) {
+    Future<Response> baselineResponseFuture =
+        executorService.submit(
+            () -> {
+              return get("application/json", path, params);
+            });
+
+    if (path.startsWith("/actuator")) {
+      /* Health checks, metrics, etc. do not have FHIR compliance requirements */
+      return ExpectedResponse.of(baselineResponseFuture.get(5, TimeUnit.MINUTES));
+    }
+
+    Future<Response> fhirJsonResponseFuture =
+        executorService.submit(
+            () -> {
+              return get("application/fhir+json", path, params);
+            });
+    Future<Response> jsonFhirResponseFuture =
+        executorService.submit(
+            () -> {
+              return get("application/json+fhir", path, params);
+            });
+
+    final Response baselineResponse = baselineResponseFuture.get(5, TimeUnit.MINUTES);
+    final Response fhirJsonResponse = fhirJsonResponseFuture.get(5, TimeUnit.MINUTES);
+    final Response jsonFhirResponse = jsonFhirResponseFuture.get(5, TimeUnit.MINUTES);
+
+    assertThat(fhirJsonResponse.getStatusCode())
+        .withFailMessage(
+            "status: application/json ("
+                + baselineResponse.getStatusCode()
+                + ") does not equal application/fhir+json ("
+                + fhirJsonResponse.getStatusCode()
+                + ")")
+        .isEqualTo(baselineResponse.getStatusCode());
+    assertThat(jsonFhirResponse.getStatusCode())
+        .withFailMessage(
+            "status: application/json ("
+                + baselineResponse.getStatusCode()
+                + ") does not equal application/json+fhir ("
+                + jsonFhirResponse.getStatusCode()
+                + ")")
+        .isEqualTo(baselineResponse.getStatusCode());
+
+    if (baselineResponse.getStatusCode() >= 400) {
+      /*
+       * Error responses must be returned as OOs but contain a timestamp in the diagnostics
+       * that prevents direct comparison.
+       */
+      assertThat(functionalEqualityCheck.equals(baselineResponse.body(), fhirJsonResponse.body()))
+          .isTrue();
+      assertThat(functionalEqualityCheck.equals(baselineResponse.body(), jsonFhirResponse.body()))
+          .isTrue();
+    } else {
+      // OK responses
+      assertThat(baselineResponse.body().asString())
+          .isEqualTo(fhirJsonResponse.body().asString())
+          .isEqualTo(jsonFhirResponse.body().asString());
+    }
+    return ExpectedResponse.of(baselineResponse);
+  }
+
+  private Response get(String contentType, String path, Object[] params) {
+    Response response = null;
+
+    // We'll make the request at least one time and as many as maxAttempts if we get a 500 error.
+    final int maxAttempts = 3;
+    for (int i = 0; i < maxAttempts; i++) {
+      if (i > 0) {
+        log.info("Making retry attempt {} for {}:{} after failure.", i, contentType, path);
+      }
+
+      response =
+          service()
+              .requestSpecification()
+              .contentType(contentType)
+              .accept(contentType)
+              .request(Method.GET, path, params);
+
+      if (response.getStatusCode() != 500) {
+        return response;
+      }
+    }
+
+    return response;
+  }
+
+  @Override
+  public ExpectedResponse post(String path, Object body) {
+    return ExpectedResponse.of(
+        service()
+            .requestSpecification()
+            .contentType("application/fhir+json")
+            .accept("application/fhir+json")
+            .body(body)
+            .request(Method.POST, path));
+  }
+}

--- a/sentinel/src/main/java/gov/va/api/health/sentinel/ResponsesAreFunctionallyEqualCheck.java
+++ b/sentinel/src/main/java/gov/va/api/health/sentinel/ResponsesAreFunctionallyEqualCheck.java
@@ -1,0 +1,7 @@
+package gov.va.api.health.sentinel;
+
+import io.restassured.response.ResponseBody;
+
+public interface ResponsesAreFunctionallyEqualCheck {
+  boolean equals(ResponseBody<?> responseBody1, ResponseBody<?> responseBody2);
+}

--- a/sentinel/src/main/java/gov/va/api/health/sentinel/SentinelProperties.java
+++ b/sentinel/src/main/java/gov/va/api/health/sentinel/SentinelProperties.java
@@ -10,7 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @UtilityClass
 public final class SentinelProperties {
-
   /** Supplies system property access-token, or throws exception if it doesn't exist. */
   public static String magicAccessToken() {
     final String magic = System.getProperty("access-token");
@@ -30,28 +29,6 @@ public final class SentinelProperties {
     }
     log.info("Using {} api path {} (Override with -D{}=<url>)", name, apiPath, property);
     return apiPath;
-  }
-
-  /**
-   * Get crawler ignores from a system property. Ignores are not factored into the crawlers result
-   * if they fail.
-   */
-  public static String optionCrawlerIgnores(String name) {
-    String ignores = System.getProperty("sentinel." + name + ".crawler.ignores");
-    if (isBlank(ignores)) {
-      log.info(
-          "No requests ignored. (Override with -Dsentinel.{}.crawler.ignores=<ignores> "
-              + "-- Place ignores in a comma separated list)",
-          name);
-    } else {
-      log.info(
-          "Ignoring the following requests: {} "
-              + "(Override with -Dsentinel.{}.crawler.ignores=<ignores> "
-              + "-- Place ignores in a comma separated list)",
-          ignores,
-          name);
-    }
-    return ignores;
   }
 
   /** Read url from a system property. */
@@ -78,16 +55,5 @@ public final class SentinelProperties {
     }
     log.info("Using {} threads (Override with -D{}=<number>)", threads, name);
     return threads;
-  }
-
-  /** Read url replacement from system property. */
-  public String urlReplace(String name) {
-    String replace = System.getProperty("sentinel." + name + ".url.replace");
-    if (isBlank(replace)) {
-      log.info("URL replacement disabled (Override with -Dsentinel.{}.url.replace=<url>)", name);
-    } else {
-      log.info("URL replacement {} (Override with -Dsentinel.{}.url.replace=<url>)", replace, name);
-    }
-    return replace;
   }
 }

--- a/sentinel/src/main/java/gov/va/api/health/sentinel/ServiceDefinition.java
+++ b/sentinel/src/main/java/gov/va/api/health/sentinel/ServiceDefinition.java
@@ -32,7 +32,8 @@ public final class ServiceDefinition {
 
   Supplier<Optional<String>> accessToken;
 
-  RequestSpecification requestSpecification() {
+  /** Returns Request Specification with or without jargonaut header. */
+  public RequestSpecification requestSpecification() {
     RequestSpecification spec =
         RestAssured.given()
             .baseUri(url())
@@ -55,7 +56,7 @@ public final class ServiceDefinition {
    * Guaranteed to return a url + path that adds / as necessary to produce a url that ends in a /.
    * e.g. https://something.com/my/cool/api/
    */
-  String urlWithApiPath() {
+  public String urlWithApiPath() {
     StringBuilder builder = new StringBuilder(url());
     if (!apiPath().startsWith("/")) {
       builder.append('/');

--- a/sentinel/src/main/java/gov/va/api/health/sentinel/categories/Smoke.java
+++ b/sentinel/src/main/java/gov/va/api/health/sentinel/categories/Smoke.java
@@ -1,0 +1,3 @@
+package gov.va.api.health.sentinel.categories;
+
+public interface Smoke {}


### PR DESCRIPTION
This will need to be the first PR accepted in the chain that is the ADQ-34 changes. PRs in
1. health-apis-data-query
2. health-apis-data-query-deployment

Changes:
- Moved FhirTestClient here from DQ
- Moved Smoke test category here from DQ
- Moved crawler properties from here to DQ. They might ultimately end up refactored if the crawler comes out but for now, its properties don't belong in in SentinelProperties

