### PR TITLE
Revert "Task/api 1364 health apis parent seperate docker build and push"

### DIFF
--- a/service-starter/pom.xml
+++ b/service-starter/pom.xml
@@ -96,7 +96,12 @@
   </build>
   <profiles>
     <profile>
-      <id>release</id>
+      <id>docker</id>
+      <activation>
+        <file>
+          <exists>src/main/resources/application.properties</exists>
+        </file>
+      </activation>
       <build>
         <plugins>
           <plugin>
@@ -137,15 +142,9 @@
             <executions>
               <execution>
                 <id>build</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>build</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>deploy</id>
                 <phase>deploy</phase>
                 <goals>
+                  <goal>build</goal>
                   <goal>push</goal>
                 </goals>
               </execution>


### PR DESCRIPTION
Reverts department-of-veterans-affairs/health-apis-parent#27

The statement that all projects that use service-starter should have a docker image produced is true, *except* for service starter itself. We'll need to pull this back and rethink what needs to happen.